### PR TITLE
Use concise rocket chat alerts

### DIFF
--- a/openshift/alerting-rule.yml
+++ b/openshift/alerting-rule.yml
@@ -11,8 +11,9 @@ spec:
     rules:
     - alert: pitc-statuscope-prod_outdated
       annotations:
-        message: Der Check {{ $labels.application }} ist veraltet oder fehlgeschlagen.
+        summary: Der Check {{ $labels.application }} ist veraltet oder fehlgeschlagen.
       expr: statuscope_check_ok{namespace="pitc-statuscope-prod"} > 1
       labels:
         rocketchat_channel: '#devruby-alerts'
+        team: devruby
         severity: critical


### PR DESCRIPTION
Specify `team: devruby` to get concise alerts in Rocket.Chat. This requires the annotation `summary` instead of `message`. Due to an own Rocket.Chat endpoint, alert messages are less verbose and focus on the relevant parts.