### PR TITLE
Separate outdated and failed state

### DIFF
--- a/app/domain/prometheus_metrics.rb
+++ b/app/domain/prometheus_metrics.rb
@@ -3,11 +3,11 @@
 # Display current heartbeat-states in prometheus format
 class PrometheusMetrics
   OK = 1
-  FAILED = 2
-  OUTDATED = 3
+  OUTDATED = 2
+  FAILED = 3
 
   HEADER = <<~TEXT
-    # HELP statuscope_check_ok Whether a check is ok (1), failing (2) or outdated (3).
+    # HELP statuscope_check_ok Whether a check is ok (1), outdated (2) or failing (3).
     # TYPE statuscope_check_ok gauge
   TEXT
 
@@ -26,8 +26,8 @@ class PrometheusMetrics
     def render_metric(heartbeat, timestamp)
       value = case heartbeat.status
               when 'ok' then OK
-              when 'fail' then FAILED
               when 'outdated' then OUTDATED
+              when 'fail' then FAILED
               else
                 FAILED
               end

--- a/app/domain/prometheus_metrics.rb
+++ b/app/domain/prometheus_metrics.rb
@@ -3,10 +3,11 @@
 # Display current heartbeat-states in prometheus format
 class PrometheusMetrics
   OK = 1
-  NOT_OK = 2
+  FAILED = 2
+  OUTDATED = 3
 
   HEADER = <<~TEXT
-    # HELP statuscope_check_ok Whether a check is ok (1) or failing (2).
+    # HELP statuscope_check_ok Whether a check is ok (1), failing (2) or outdated (3).
     # TYPE statuscope_check_ok gauge
   TEXT
 
@@ -23,7 +24,14 @@ class PrometheusMetrics
     private
 
     def render_metric(heartbeat, timestamp)
-      value = heartbeat.ok? ? OK : NOT_OK
+      value = case heartbeat.status
+              when 'ok' then OK
+              when 'fail' then FAILED
+              when 'outdated' then OUTDATED
+              else
+                FAILED
+              end
+
       app = heartbeat.application
       team = heartbeat.team
 

--- a/app/models/heartbeat.rb
+++ b/app/models/heartbeat.rb
@@ -31,13 +31,10 @@ class Heartbeat < ApplicationRecord
   end
 
   def status
+    return 'fail'     unless last_signal_ok?
     return 'outdated' unless last_signal_recent?
 
-    if last_signal_ok?
-      'ok'
-    else
-      'fail'
-    end
+    'ok'
   end
 
   def ok?

--- a/app/models/heartbeat.rb
+++ b/app/models/heartbeat.rb
@@ -22,12 +22,22 @@ class Heartbeat < ApplicationRecord
     {
       application: application,
       team: team,
-      state: ok? ? 'ok' : 'fail',
+      state: status,
       last_signal_ok: last_signal_ok?,
       last_signal_recent: last_signal_recent?,
       check_in: last_signal_at,
       interval: interval_seconds
     }
+  end
+
+  def status
+    return 'outdated' unless last_signal_recent?
+
+    if last_signal_ok?
+      'ok'
+    else
+      'fail'
+    end
   end
 
   def ok?

--- a/openshift/alerting-rule.yml
+++ b/openshift/alerting-rule.yml
@@ -9,12 +9,19 @@ spec:
   groups:
   - name: pitc-statuscope-prod_alerts
     rules:
-    - alert: pitc-statuscope-prod_outdated
+    - alert: statuscope outdated
       annotations:
-        summary: Der Check {{ $labels.application }} ist veraltet oder fehlgeschlagen.
-      expr: statuscope_check_ok{namespace="pitc-statuscope-prod"} > 1
+        summary: Der Check {{ $labels.application }} ist veraltet.
+      expr: statuscope_check_ok{namespace="pitc-statuscope-prod"} = 3
       labels:
         rocketchat_channel: '#devruby-alerts'
         severity: critical
         instance: '{{ $labels.application }}'
-
+    - alert: statuscope fail
+      annotations:
+        summary: Der Check {{ $labels.application }} ist fehlgeschlagen.
+      expr: statuscope_check_ok{namespace="pitc-statuscope-prod"} = 2
+      labels:
+        rocketchat_channel: '#devruby-alerts'
+        severity: critical
+        instance: '{{ $labels.application }}'

--- a/spec/domain/prometheus_metrics_spec.rb
+++ b/spec/domain/prometheus_metrics_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe PrometheusMetrics, type: :model do
     hdr_help, hdr_type, good_line, bad_line, old_line = lines
 
     expect(hdr_help).to eq(
-      '# HELP statuscope_check_ok Whether a check is ok (1), failing (2) or outdated (3).'
+      '# HELP statuscope_check_ok Whether a check is ok (1), outdated (2) or failing (3).'
     )
     expect(hdr_type).to eq('# TYPE statuscope_check_ok gauge')
 
     expect(good_line).to match(/statuscope_check_ok{application="good_app",team="puzzle"} 1 \d+$/)
-    expect(bad_line).to match(/statuscope_check_ok{application="bad_app",team="careless"} 2 \d+$/)
-    expect(old_line).to match(/statuscope_check_ok{application="old_app",team="nakatomi"} 3 \d+$/)
+    expect(bad_line).to match(/statuscope_check_ok{application="bad_app",team="careless"} 3 \d+$/)
+    expect(old_line).to match(/statuscope_check_ok{application="old_app",team="nakatomi"} 2 \d+$/)
   end
 end

--- a/spec/domain/prometheus_metrics_spec.rb
+++ b/spec/domain/prometheus_metrics_spec.rb
@@ -11,17 +11,25 @@ RSpec.describe PrometheusMetrics, type: :model do
     Fabricate(:heartbeat, application: 'bad_app', last_signal_ok: false, team: 'careless')
   end
 
+  let(:died_heart) do
+    Fabricate(:heartbeat, application: 'old_app', last_signal_ok: true, team: 'nakatomi',
+                          interval_seconds: 10, last_signal_at: 15.seconds.ago)
+  end
+
   it '.render' do
-    lines = PrometheusMetrics.render([good_heart, broken_heart]).split("\n")
+    lines = PrometheusMetrics.render([good_heart, broken_heart, died_heart]).split("\n")
 
-    expect(lines.count).to eq(4)
+    expect(lines.count).to eq(5)
 
-    hdr_help, hdr_type, good_line, bad_line = lines
+    hdr_help, hdr_type, good_line, bad_line, old_line = lines
 
-    expect(hdr_help).to eq('# HELP statuscope_check_ok Whether a check is ok (1) or failing (2).')
+    expect(hdr_help).to eq(
+      '# HELP statuscope_check_ok Whether a check is ok (1), failing (2) or outdated (3).'
+    )
     expect(hdr_type).to eq('# TYPE statuscope_check_ok gauge')
 
     expect(good_line).to match(/statuscope_check_ok{application="good_app",team="puzzle"} 1 \d+$/)
     expect(bad_line).to match(/statuscope_check_ok{application="bad_app",team="careless"} 2 \d+$/)
+    expect(old_line).to match(/statuscope_check_ok{application="old_app",team="nakatomi"} 3 \d+$/)
   end
 end

--- a/spec/models/heartbeat_spec.rb
+++ b/spec/models/heartbeat_spec.rb
@@ -43,6 +43,65 @@ RSpec.describe Heartbeat, type: :model do
     end
   end
 
+  describe '#status' do
+    let(:last_signal_ok) { true }
+    let(:heartbeat) do
+      Fabricate(:heartbeat,
+                last_signal_ok: last_signal_ok,
+                last_signal_at: last_signal_at,
+                interval_seconds: interval)
+    end
+
+    describe 'with interval' do
+      let(:interval) { 1.hour.to_i }
+
+      describe 'inside interval' do
+        let(:last_signal_at) { Time.zone.now - interval / 2 }
+
+        describe 'last signal ok' do
+          it 'is ok' do
+            expect(heartbeat.status).to eql 'ok'
+          end
+        end
+
+        describe 'last signal not ok' do
+          let(:last_signal_ok) { false }
+
+          it 'is fail' do
+            expect(heartbeat.status).to eql 'fail'
+          end
+        end
+      end
+
+      describe 'outside interval' do
+        let(:last_signal_at) { Time.zone.now - interval * 2 }
+
+        it 'is outdated' do
+          expect(heartbeat.status).to eql 'outdated'
+        end
+      end
+    end
+
+    describe 'without interval, last signal years ago' do
+      let(:interval) { 0 }
+      let(:last_signal_at) { 2.years.ago }
+
+      describe 'and ok,' do
+        it 'is ok' do
+          expect(heartbeat.status).to eql 'ok'
+        end
+      end
+
+      describe 'but not ok,' do
+        let(:last_signal_ok) { false }
+
+        it 'is fail' do
+          expect(heartbeat.status).to eql 'fail'
+        end
+      end
+    end
+  end
+
   describe '#ok?' do
     let(:last_signal_ok) { true }
     let(:heartbeat) do


### PR DESCRIPTION
Even with the current alerting rule in place, this works. With the newer alerting rule, both states are separated.