### PR TITLE
Allow securing the checks#metrics-action

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -2,6 +2,9 @@
 
 # Endpoints to get the current state of all Heartbearts
 class ChecksController < ApplicationController
+  include BearerTokenAuthentication # provides authenticate_bearer_token
+  before_action :authenticate_bearer_token, only: :metrics
+
   def index
     render json: Heartbeat.all, status: :ok
   end
@@ -14,4 +17,8 @@ class ChecksController < ApplicationController
   def metrics
     render plain: PrometheusMetrics.render(Heartbeat.all)
   end
+
+  private
+
+  def expected_token_env_var_name = 'METRICS_TOKEN'
 end

--- a/app/controllers/concerns/bearer_token_authentication.rb
+++ b/app/controllers/concerns/bearer_token_authentication.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Allow for Token-Authentication
+module BearerTokenAuthentication
+  private
+
+  # the return-value is not really checked, the action halted if a
+  # redirect or render happened in the hook. However, the boolean
+  # return-value communicates better the "result" and also helps
+  # to prevent rubocop from auto-fixing the happy-path into the
+  # middle of the method.
+  def authenticate_bearer_token
+    return true if no_token_set?
+
+    if auth_header.nil? || !auth_header.start_with?('Bearer ')
+      render plain: '', status: :unauthorized and return false
+    end
+
+    if provided_token != expected_token
+      Rails.logger.warn('Invalid bearer token')
+      render plain: '', status: :forbidden and return false
+    end
+
+    true
+  end
+
+  def expected_token_env_var_name
+    raise 'Please set #expected_token_env_var_name in your controller when using BearerTokenAuthentication'
+  end
+
+  def expected_token
+    ENV[expected_token_env_var_name]
+  end
+
+  def auth_header
+    request.headers['Authorization']
+  end
+
+  def provided_token
+    auth_header.sub('Bearer ', '').strip
+  end
+
+  def no_token_set?
+    return true if expected_token.blank?
+
+    Rails.logger.warn("#{expected_token_env_var_name} not set; allowing access")
+    false
+  end
+end

--- a/spec/controllers/checks_controller_spec.rb
+++ b/spec/controllers/checks_controller_spec.rb
@@ -37,17 +37,62 @@ RSpec.describe ChecksController, type: :controller do
   end
 
   describe 'GET #metrics' do
-    describe 'ok heartbeat' do
-      let!(:heartbeat) do
-        Fabricate(:heartbeat, last_signal_ok: true, interval_seconds: 0)
+    let!(:heartbeat) do
+      Fabricate(:heartbeat, last_signal_ok: true, interval_seconds: 0)
+    end
+
+    context 'with no METRICS_TOKEN configured' do
+      around do |example|
+        before = ENV.delete('METRICS_TOKEN')
+        example.call
+      ensure
+        ENV['METRICS_TOKEN'] = before if before.present?
       end
 
       it 'returns prometheus metrics' do
         get :metrics
         expect(response).to have_http_status(:success)
-        expect(response.body).to match(
-          /# HELP .*\n# TYPE.*\nstatuscope_check_ok.*/
-        )
+        expect(response.body).to match(/# HELP .*TYPE.*statuscope_check_ok.*/m)
+      end
+    end
+
+    context 'with a METRICS_TOKEN configured' do
+      let(:valid_token) { 'i-am-a-metrics-token-and-i-m-allright' }
+
+      around do |example|
+        before = ENV['METRICS_TOKEN']
+        ENV['METRICS_TOKEN'] = valid_token
+        example.call
+      ensure
+        ENV.delete('METRICS_TOKEN')
+        ENV['METRICS_TOKEN'] = before if before.present?
+      end
+
+      it 'with valid bearer token, it returns prometheus metrics' do
+        request.headers['Authorization'] = "Bearer #{valid_token}"
+        get :metrics
+        expect(response).to have_http_status(:success)
+        expect(response.body).to match(/# HELP .*TYPE.*statuscope_check_ok.*/m)
+      end
+
+      it 'unauthenticated (no token), it returns 401 with empty body' do
+        get :metrics
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to be_empty
+      end
+
+      it 'unauthorized (wrong token), it returns 403 with empty body' do
+        request.headers['Authorization'] = 'Bearer wrong-token'
+        get :metrics
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to be_empty
+      end
+
+      it 'with malformed header, it returns 401 with empty body' do
+        request.headers['Authorization'] = 'Bearer' # No token
+        get :metrics
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to be_empty
       end
     end
   end


### PR DESCRIPTION
It is mostly used by prometheus, which can provide a Bearer-token. Since the endpoint shows all checks in the application with their current signals, a little discretion is advised. The endpoint can of course also be only made available in the internal network, but this gives more flexibility.